### PR TITLE
Show title and detail in debug mode only

### DIFF
--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -19,6 +19,13 @@ class ExceptionListener
 
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
-        $event->setResponse(new ProblemResponse(new Exception($event->getException(), $this->debugMode)));
+        $event->setResponse(
+            new ProblemResponse(
+                new Exception($event->getException(), $this->debugMode),
+                null,
+                array(),
+                $this->debugMode
+            )
+        );
     }
 }

--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ProblemListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ProblemListener.php
@@ -17,18 +17,18 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class ProblemListener
 {
-
     private $reader;
 
-    public function __construct(Reader $reader)
+    private $debugMode;
+
+    public function __construct(Reader $reader, $debugMode)
     {
         $this->reader = $reader;
+        $this->debugMode = $debugMode;
     }
-
 
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
-
         $request = $event->getRequest();
         $resource = $event->getControllerResult();
         
@@ -43,7 +43,7 @@ class ProblemListener
         }
 
         $headers = array('Content-type' => 'application/api-problem+json');
-        $response = new ProblemResponse($resource, 400, $headers);
+        $response = new ProblemResponse($resource, 400, $headers, $this->debugMode);
         $event->setResponse($response);
     }
 

--- a/src/Alterway/Bundle/RestProblemBundle/Resources/config/services.yml
+++ b/src/Alterway/Bundle/RestProblemBundle/Resources/config/services.yml
@@ -5,12 +5,15 @@ parameters:
 services:
   aw.rest_problem.listener:
     class: %aw.rest_problem.listener.class%
-    arguments: [@annotation_reader]
+    arguments:
+        - @annotation_reader
+        - %kernel.debug%
     tags:
       - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
 
   aw.rest_exception.listener:
     class: %aw.rest_exception.listener.class%
-    arguments: [%kernel.debug%]
+    arguments:
+        - %kernel.debug%
     tags:
       - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }

--- a/src/Alterway/Bundle/RestProblemBundle/Response/ProblemResponse.php
+++ b/src/Alterway/Bundle/RestProblemBundle/Response/ProblemResponse.php
@@ -14,14 +14,16 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class ProblemResponse extends JsonResponse
 {
-
-    public function __construct(ProblemInterface $problem, $status = null, $headers = array())
+    public function __construct(ProblemInterface $problem, $status = null, $headers = array(), $debugMode = true)
     {
         $datas = array(
-            'problemType' => $problem->getProblemType()
-            , 'title' => $problem->getTitle()
-            , 'detail' => $problem->getDetail()
+            'problemType' => $problem->getProblemType(),
         );
+
+        if ($debugMode) {
+            $datas['title'] = $problem->getTitle();
+            $datas['detail'] = $problem->getDetail();
+        }
 
         if (null === $status) {
             $status = $problem->getHttpStatus();
@@ -29,5 +31,4 @@ class ProblemResponse extends JsonResponse
 
         parent::__construct($datas, $status, $headers);
     }
-
 }

--- a/test/unit/Response/ProblemResponseTest.php
+++ b/test/unit/Response/ProblemResponseTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Alterway\Bundle\RestProblemBundle\Problem\Problem;
+use Alterway\Bundle\RestProblemBundle\Response\ProblemResponse;
+
+class ProblemResponseTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_does_not_contain_title_nor_detail_when_debug_mode_is_off()
+    {
+        $problem = $this->createProblem();
+        $response = new ProblemResponse($problem, 400, array(), $debugMode = false);
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode(
+                array(
+                    'problemType' => 'exception',
+                )
+            ),
+            $response->getContent()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_contains_title_and_detail_when_debug_mode_is_on()
+    {
+        $problem = $this->createProblem();
+        $response = new ProblemResponse($problem, 400, array(), $debugMode = true);
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode(
+                array(
+                    'problemType' => 'exception',
+                    'title' => 'An error occured',
+                    'detail' => 'Sensitive details',
+                )
+            ),
+            $response->getContent()
+        );
+    }
+
+    private function createProblem()
+    {
+        $problem = new Problem();
+
+        $problem->setProblemType('exception');
+        $problem->setTitle('An error occured');
+        $problem->setDetail('Sensitive details');
+
+        return $problem;
+    }
+}


### PR DESCRIPTION
ref https://github.com/lrqdo/back-web/issues/2186

Do not show title and detail when error mode is off, since we should not expose exception details in production.

#### Before
```json
// debug = false

HTTP/1.1 403 Forbidden
{
    "detail": "#0 /var/www/app/api/vendor/symfony/symfony/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php(97): Symfony\\Component\\Security\\Http\\Firewall\\ExceptionListener->handleAccessDeniedException(Object(Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent), Object(Symfony\\Component\\Security\\Core\\Exception\\AccessDeniedException))\n#1 [internal function]: Symfony\\Component\\Security\\Http\\Firewall\\ExceptionListener->onKernelException(Object(Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent), 'kernel.exceptio...', Object(Symfony\\Component\\HttpKernel\\Debug\\TraceableEventDispatcher))\n#2 /var/www/app/api/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php(61): call_user_func(Array, Object(Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent), 'kernel.exceptio...', Object(Symfony\\Component\\HttpKernel\\Debug\\TraceableEventDispatcher))\n#3 [internal function]: Symfony\\Component\\EventDispatcher\\Debug\\WrappedListener->__invoke(Object(Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent), 'kernel.exceptio...', Object(Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher))\n#4 /tmp/back-web/app/api/cache/dev/classes.php(2281): call_user_func(Object(Symfony\\Component\\EventDispatcher\\Debug\\WrappedListener), Object(Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent), 'kernel.exceptio...', Object(Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher))\n#5 /tmp/back-web/app/api/cache/dev/classes.php(2210): Symfony\\Component\\EventDispatcher\\EventDispatcher->doDispatch(Array, 'kernel.exceptio...', Object(Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent))\n#6 /var/www/app/api/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php(124): Symfony\\Component\\EventDispatcher\\EventDispatcher->dispatch('kernel.exceptio...', Object(Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent))\n#7 /var/www/app/api/bootstrap.php.cache(3139): Symfony\\Component\\EventDispatcher\\Debug\\TraceableEventDispatcher->dispatch('kernel.exceptio...', Object(Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent))\n#8 /var/www/app/api/bootstrap.php.cache(3075): Symfony\\Component\\HttpKernel\\HttpKernel->handleException(Object(Symfony\\Component\\Security\\Core\\Exception\\AccessDeniedException), Object(Symfony\\Component\\HttpFoundation\\Request), 1)\n#9 /var/www/app/api/bootstrap.php.cache(3220): Symfony\\Component\\HttpKernel\\HttpKernel->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)\n#10 /var/www/app/api/bootstrap.php.cache(2439): Symfony\\Component\\HttpKernel\\DependencyInjection\\ContainerAwareHttpKernel->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)\n#11 /var/www/src/Lrqdo/Infrastructure/Stack/Maintenance.php(44): Symfony\\Component\\HttpKernel\\Kernel->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)\n#12 /var/www/src/Lrqdo/Infrastructure/Stack/HostName.php(22): Lrqdo\\Infrastructure\\Stack\\Maintenance->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)\n#13 /var/www/src/Lrqdo/Infrastructure/Stack/Version.php(25): Lrqdo\\Infrastructure\\Stack\\HostName->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)\n#14 /var/www/app/api/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Lrqdo\\Infrastructure\\Stack\\Version->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 1, true)\n#15 /var/www/app/api/web/app_dev.php(25): Stack\\StackedHttpKernel->handle(Object(Symfony\\Component\\HttpFoundation\\Request))\n#16 /var/www/app/api/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_dev.php(40): require('/var/www/app/ap...')\n#17 {main}", 
    "problemType": "/exception", 
    "title": "Access Denied."
}
```

#### After
```json
// debug = false

HTTP/1.1 403 Forbidden
{
    "problemType": "/exception"
}
```