### PR TITLE
Use Symfony logger to log exceptions.

### DIFF
--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -5,18 +5,64 @@ namespace Alterway\Bundle\RestProblemBundle\EventListener;
 use Alterway\Bundle\RestProblemBundle\Problem\Exception;
 use Alterway\Bundle\RestProblemBundle\Response\ProblemResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class ExceptionListener
 {
     private $debugMode;
 
-    public function __construct($debugMode)
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct($debugMode, LoggerInterface $logger = null)
     {
         $this->debugMode = $debugMode;
+        if (null !== $logger) {
+            $this->logger = $logger;
+        } else {
+            $this->logger = new NullLogger();
+        }
     }
 
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
-        $event->setResponse(new ProblemResponse(new Exception($event->getException(), $this->debugMode)));
+        $exception = $event->getException();
+
+        $this->logException(
+            $exception,
+            sprintf(
+                'Uncaught PHP Exception %s: "%s" at %s line %s',
+                get_class($exception),
+                $exception->getMessage(),
+                $exception->getFile(),
+                $exception->getLine()
+            )
+        );
+
+        $event->setResponse(new ProblemResponse(new Exception($exception, $this->debugMode)));
+    }
+
+    /**
+     * Logs an exception.
+     * Taken from https://github.com/symfony/symfony/blob/d97279e942bf3a135634ad90a32f1d5cd05a22ba/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+     *
+     * @param \Exception $exception The \Exception instance
+     * @param string     $message   The error message to log
+     * @param bool       $original  False when the handling of the exception thrown another exception
+     */
+    protected function logException(\Exception $exception, $message, $original = true)
+    {
+        $isCritical = !$exception instanceof HttpExceptionInterface || $exception->getStatusCode() >= 500;
+        $context = array('exception' => $exception);
+        if (null !== $this->logger) {
+            if ($isCritical) {
+                $this->logger->critical($message, $context);
+            } else {
+                $this->logger->error($message, $context);
+            }
+        } elseif (!$original || $isCritical) {
+            error_log($message);
+        }
     }
 }

--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -48,9 +48,8 @@ class ExceptionListener
      *
      * @param \Exception $exception The \Exception instance
      * @param string     $message   The error message to log
-     * @param bool       $original  False when the handling of the exception thrown another exception
      */
-    protected function logException(\Exception $exception, $message, $original = true)
+    protected function logException(\Exception $exception, $message)
     {
         $isCritical = !$exception instanceof HttpExceptionInterface || $exception->getStatusCode() >= 500;
         $context = array('exception' => $exception);
@@ -60,7 +59,7 @@ class ExceptionListener
             } else {
                 $this->logger->error($message, $context);
             }
-        } elseif (!$original || $isCritical) {
+        } elseif ($isCritical) {
             error_log($message);
         }
     }

--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -6,7 +6,6 @@ use Alterway\Bundle\RestProblemBundle\Problem\Exception;
 use Alterway\Bundle\RestProblemBundle\Response\ProblemResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 class ExceptionListener
 {
@@ -15,14 +14,14 @@ class ExceptionListener
     /** @var LoggerInterface */
     private $logger;
 
-    public function __construct($debugMode, LoggerInterface $logger = null)
+    public function __construct($debugMode)
     {
         $this->debugMode = $debugMode;
-        if (null !== $logger) {
-            $this->logger = $logger;
-        } else {
-            $this->logger = new NullLogger();
-        }
+    }
+
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
     }
 
     public function onKernelException(GetResponseForExceptionEvent $event)

--- a/src/Alterway/Bundle/RestProblemBundle/Resources/config/services.yml
+++ b/src/Alterway/Bundle/RestProblemBundle/Resources/config/services.yml
@@ -11,8 +11,8 @@ services:
 
   aw.rest_exception.listener:
     class: %aw.rest_exception.listener.class%
-    arguments:
-      - %kernel.debug%
-      - @?logger
+    arguments: [%kernel.debug%]
+    calls:
+      - [setLogger, ['@?logger']]
     tags:
       - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }

--- a/src/Alterway/Bundle/RestProblemBundle/Resources/config/services.yml
+++ b/src/Alterway/Bundle/RestProblemBundle/Resources/config/services.yml
@@ -11,6 +11,8 @@ services:
 
   aw.rest_exception.listener:
     class: %aw.rest_exception.listener.class%
-    arguments: [%kernel.debug%]
+    arguments:
+      - %kernel.debug%
+      - @?logger
     tags:
       - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }


### PR DESCRIPTION
This is closer to Symfony's default behaviour. Otherwise all exceptions
are actually swallowed in terms of logging.