### PR TITLE
Enable logging exceptions

### DIFF
--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -24,7 +24,7 @@ class ExceptionListener
 
     public function onKernelResponse(FilterResponseEvent $event)
     {
-        if ($event->getResponse()->isServerError()) {
+        if (null !== $this->exception) {
             $event->setResponse(new ProblemResponse(new Exception($this->exception, $this->debugMode)));
         }
     }

--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -27,7 +27,13 @@ class ExceptionListener
         // We render the response here and not in the `onKernelException` method because otherwise
         // Symfony's default exception listener would not run, and the exception would not be logged.
         if (null !== $this->exception) {
-            $event->setResponse(new ProblemResponse(new Exception($this->exception, $this->debugMode)));
+            $event->setResponse(
+                new ProblemResponse(
+                    new Exception($this->exception, $this->debugMode),
+                    null,
+                    $event->getResponse()->headers->all()
+                )
+            );
         }
     }
 }

--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -5,10 +5,12 @@ namespace Alterway\Bundle\RestProblemBundle\EventListener;
 use Alterway\Bundle\RestProblemBundle\Problem\Exception;
 use Alterway\Bundle\RestProblemBundle\Response\ProblemResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 class ExceptionListener
 {
     private $debugMode;
+    private $exception;
 
     public function __construct($debugMode)
     {
@@ -17,6 +19,13 @@ class ExceptionListener
 
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
-        $event->setResponse(new ProblemResponse(new Exception($event->getException(), $this->debugMode)));
+        $this->exception = $event->getException();
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if ($event->getResponse()->isServerError()) {
+            $event->setResponse(new ProblemResponse(new Exception($this->exception, $this->debugMode)));
+        }
     }
 }

--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -24,6 +24,8 @@ class ExceptionListener
 
     public function onKernelResponse(FilterResponseEvent $event)
     {
+        // We render the response here and not in the `onKernelException` method because otherwise
+        // Symfony's default exception listener would not run, and the exception would not be logged.
         if (null !== $this->exception) {
             $event->setResponse(new ProblemResponse(new Exception($this->exception, $this->debugMode)));
         }

--- a/src/Alterway/Bundle/RestProblemBundle/Resources/config/services.yml
+++ b/src/Alterway/Bundle/RestProblemBundle/Resources/config/services.yml
@@ -14,3 +14,4 @@ services:
     arguments: [%kernel.debug%]
     tags:
       - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
+      - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }


### PR DESCRIPTION
The exception listener was not compatible with Symfony's exception
listener: they both set a Response, so they both stop the exception
event propagation.

With this change, the listener first stores a reference to the thrown
exception, then lets Symfony's exception listener log the exception and
rendering the error page (unfortunately this is done in the same
listener, an issue has been opened [here](https://github.com/symfony/symfony/issues/18552)). Then the
listener waits for a response event, checks if an exception was thrown previously, and if so,
 it's returns the RestProblem custom response as it did before, thus keeping backward compatibility.