### PR TITLE
log HttpException as Info

### DIFF
--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -51,10 +51,12 @@ class ExceptionListener
      */
     protected function logException(\Exception $exception, $message)
     {
-        $isCritical = !$exception instanceof HttpExceptionInterface || $exception->getStatusCode() >= 500;
+        $isCritical = $exception->getStatusCode() >= 500;
         $context = array('exception' => $exception);
         if (null !== $this->logger) {
-            if ($isCritical) {
+            if ($exception instanceof HttpExceptionInterface) {
+                $this->logger->info($message, $context);
+            } else if ($isCritical) {
                 $this->logger->critical($message, $context);
             } else {
                 $this->logger->error($message, $context);


### PR DESCRIPTION
## Desc
Log HttpException as info

## Why
Trigger monitoring for no reason (NotFoundHttpException for example)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208292589386458