### PR TITLE
Ignore Logic && Assert exceptions

### DIFF
--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -29,7 +29,11 @@ class ExceptionListener
         $exception = method_exists($event, 'getThrowable') ? $event->getThrowable() : $event->getException();
 
         if (extension_loaded('newrelic')) {
-            if (!$exception instanceof HttpExceptionInterface || $exception->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
+            if (
+                !$exception instanceof LogicException &&
+                !$exception instanceof HttpExceptionInterface &&
+                !$exception instanceof Assert\InvalidArgumentException
+            ) {
                 newrelic_notice_error($exception->getMessage(), $exception);
                 newrelic_add_custom_parameter('file', $exception->getFile());
                 newrelic_add_custom_parameter('line', $exception->getLine());

--- a/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
+++ b/src/Alterway/Bundle/RestProblemBundle/EventListener/ExceptionListener.php
@@ -32,7 +32,8 @@ class ExceptionListener
             if (
                 !$exception instanceof LogicException &&
                 !$exception instanceof HttpExceptionInterface &&
-                !$exception instanceof Assert\InvalidArgumentException
+                !$exception instanceof Assert\InvalidArgumentException &&
+                !$exception instanceof Doctrine\DBAL\Exception\UniqueConstraintViolationException
             ) {
                 newrelic_notice_error($exception->getMessage(), $exception);
                 newrelic_add_custom_parameter('file', $exception->getFile());

--- a/src/Alterway/Bundle/RestProblemBundle/Problem/Exception.php
+++ b/src/Alterway/Bundle/RestProblemBundle/Problem/Exception.php
@@ -19,6 +19,9 @@ class Exception extends Problem
             case $exception instanceof HttpExceptionInterface;
                 $this->httpStatus = $exception->getStatusCode();
                 break;
+            case $exception instanceof Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+                $this->httpStatus = Response::HTTP_CONFLICT;
+                break;
             case $exception instanceof \LogicException:
                 $this->httpStatus = Response::HTTP_BAD_REQUEST;
                 break;


### PR DESCRIPTION
## Desc
Ne pas forwarder les exceptions Assert et Logic

## Why
Ne necessitent pas de correction, ce sont des infos. Et on ne peut pas les ignorer dans la config newrelic:


```
; Setting: newrelic.error_collector.ignore_exceptions
; Type:    string
; Scope:   per-directory
; Default: none
; Info:    A comma separated list of exception classes that the agent should
;          ignore. When an unhandled exception occurs, the agent will perform
;          the equivalent of `$exception instanceof Class` for each of the
;          classes listed. If any of those checks returns true, the agent
;          will not record an error.
;
;          Please note that this setting only applies to uncaught exceptions.
;          Exceptions recorded using the newrelic_notice_error API are not
;          subject to filtering.
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208489177384069